### PR TITLE
Feat/verify improvement

### DIFF
--- a/src/data_structures/mmr/proof.cairo
+++ b/src/data_structures/mmr/proof.cairo
@@ -17,12 +17,14 @@ impl ProofImpl of ProofTrait {
     fn compute_peak(self: Proof, index: usize, value: felt252) -> felt252 {
         let mut hash = PoseidonHasher::hash_double(index.into(), value);
 
+        // calculate direction array
+        // direction[i] - whether the i-th node from the root is a left or a right child of its parent
         let mut bits = bit_length(index);
         if self.len() + 1 > bits {
             bits = self.len() + 1;
         };
 
-        let mut path = ArrayTrait::new();
+        let mut direction: Array<bool> = ArrayTrait::new();
         let mut p: usize = 1;
         let mut q: usize = pow(2, bits) - 1;
 
@@ -34,14 +36,15 @@ impl ProofImpl of ProofTrait {
 
             if index < m {
                 q = m - 1;
-                path.append(0); // TODO: probably use booleans to save space
+                direction.append(false);
             } else {
                 p = m;
                 q = q - 1;
-                path.append(1);
+                direction.append(true);
             };
         };
 
+        // find the root hash, starting from the leaf
         let mut current_index = index;
         let mut i: usize = 0;
         loop {

--- a/src/data_structures/mmr/proof.cairo
+++ b/src/data_structures/mmr/proof.cairo
@@ -47,12 +47,13 @@ impl ProofImpl of ProofTrait {
         // find the root hash, starting from the leaf
         let mut current_index = index;
         let mut i: usize = 0;
+        let mut two_pow_i: usize = 2;
         loop {
             if i == self.len() {
                 break hash;
             }
 
-            if *path.at(path.len() - i - 1) == 1 {
+            if *direction.at(direction.len() - i - 1) {
                 // right child
                 let hashed = PoseidonHasher::hash_double(*self.at(i), hash);
 
@@ -62,11 +63,12 @@ impl ProofImpl of ProofTrait {
                 // left child
                 let hashed = PoseidonHasher::hash_double(hash, *self.at(i));
 
-                current_index += left_shift(2, i);
+                current_index += two_pow_i;
                 hash = PoseidonHasher::hash_double(current_index.into(), hashed);
             }
 
             i += 1;
+            two_pow_i *= 2;
         }
     }
 }


### PR DESCRIPTION
Algorithm improvement for verifying the proof. Changes its time complexity from O(log^2(n)) to O(log(n)) by removing `getHeight` calls which were used to determine if a node is a right or a left child. Now it uses binary search algorithm to find direction array.